### PR TITLE
Fix HTML head structure and alt text

### DIFF
--- a/df.css
+++ b/df.css
@@ -1,4 +1,4 @@
-body { margin: 0px; padding: 0px; text-align: justify; ; color: rgb(0, 0, 0); font-size:14px; font-family:'Segoe UI','Lucida Grande',Verdana,Arial,Helvetica,sans-serif; background-color:rgb(255,255,255) ; }
+body { margin: 0px; padding: 0px; text-align: justify; color: rgb(0, 0, 0); font-size:14px; font-family:'Segoe UI','Lucida Grande',Verdana,Arial,Helvetica,sans-serif; background-color:rgb(255,255,255) ; }
 h1.title { margin: 0px 10px 30px; padding: 14px; padding-top: 18px; font-size: 100%; line-height: 28px; color: rgb(255, 255, 255); }
 h1 { margin: 0px 0px 0px 0px; font-size: 150%; line-height: 28px; font-weight: 900; color: black; }
 h2 { font-weight: normal; font-size: 125%; line-height: normal; color: rgb(153, 0, 0); }

--- a/index.html
+++ b/index.html
@@ -1,12 +1,11 @@
+<!DOCTYPE html>
 <html>
-<meta name="DESCRIPTION" content="Homepage of David Ferman">
-<meta name="KEYWORDS" content="David Ferman, AI Foundation, Doma, Flawless AI, UT Austin, Univ. Florida">
-<title>David Ferman</title>
-
 <head>
+  <meta name="DESCRIPTION" content="Homepage of David Ferman">
+  <meta name="KEYWORDS" content="David Ferman, AI Foundation, Doma, Flawless AI, UT Austin, Univ. Florida">
+  <title>David Ferman</title>
   <link rel="stylesheet" type="text/css" href="df.css">
 </head>
-<!--  -->
 
 <body>
   <div id="Content" align="center">
@@ -21,7 +20,7 @@
             <p align="justify">
               David Ferman is a Deep Learning / Computer Vision researcher, currently working at <a
                 href="https://flawlessai.com/"> Flawless AI</a>, with supervision from <a
-                href="https://www.semanticscholar.org/author/Pablo-Garrido/39912094">Pablo Garido, PhD</a>. His current
+                href="https://www.semanticscholar.org/author/Pablo-Garrido/39912094">Pablo Garrido, PhD</a>. His current
               work focuses on 2D/3D facial landmark detection, facial semantic parsing, transformer/attention-based
               computer
               vision techniques, and multi-dataset/domain learning. He has previously worked as a Research Engineer at
@@ -43,7 +42,7 @@
             </p>
           </td>
           <td>
-            <img src="./profile/davidferman_v0.png" border="1" width="250">
+            <img src="./profile/davidferman_v0.png" border="1" width="250" alt="David Ferman">
           </td>
         </tr>
       </tbody>
@@ -53,7 +52,7 @@
     <table border="0">
       <tr>
         <td>
-          <img src="papers/geo-keypoint-cvpr-2023.png" border="1" width="125">
+          <img src="papers/geo-keypoint-cvpr-2023.png" border="1" width="125" alt="Few-shot Geometry-Aware Keypoint Localization">
         </td>
         <td>
           <a href="https://xingzhehe.github.io/FewShot3DKP/">Few-shot Geometry-Aware Keypoint Localization</a>
@@ -63,7 +62,7 @@
       </tr>
       <tr>
         <td>
-          <img src="papers/mdmd-2022.png" border="1" width="125">
+          <img src="papers/mdmd-2022.png" border="1" width="125" alt="Multi-Domain Multi-Definition Landmark Localization">
         </td>
         <td>
           <a href="https://arxiv.org/abs/2203.10358">Multi-Domain Multi-Definition Landmark Localization for Small
@@ -75,7 +74,7 @@
       </tr>
       <tr>
         <td>
-          <img src="papers/eg_pos_2021.png" border="1" width="125">
+          <img src="papers/eg_pos_2021.png" border="1" width="125" alt="Generative Landmarks">
         </td>
         <td>
           <a href="https://diglib.eg.org/handle/10.2312/egp20211029">Generative Landmarks</a>


### PR DESCRIPTION
## Summary
- move metadata into the `<head>` and add `<!DOCTYPE html>`
- correct Pablo Garrido's name
- add missing `alt` attributes to images
- fix typo in CSS

## Testing
- `tidy -errors -quiet index.html`

------
https://chatgpt.com/codex/tasks/task_e_686f005627608332a3a065cd8aca7b5a